### PR TITLE
Fixed exclamation points missing in tests

### DIFF
--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -7,7 +7,11 @@
         <sourceTestOutputDir name="target/generated-test-sources/test-annotations" />
         <outputRelativeToContentRoot value="true" />
         <module name="ghmvntst" />
+        <module name="devops-vis-project" />
       </profile>
     </annotationProcessing>
+    <bytecodeTargetLevel>
+      <module name="ghmvntst" target="21" />
+    </bytecodeTargetLevel>
   </component>
 </project>

--- a/src/test/java/ie/atu/devops/GreetTest.java
+++ b/src/test/java/ie/atu/devops/GreetTest.java
@@ -5,10 +5,10 @@ import junit.framework.TestCase;
 public class GreetTest extends TestCase {
 
     public void testGreetHello() {
-        assertEquals("Hello", Greet.greet(1));
+        assertEquals("Hello!", Greet.greet(1));
     }
 
     public void testGreetGoodbye() {
-        assertEquals("Goodbye", Greet.greet(2));
+        assertEquals("Goodbye!", Greet.greet(2));
     }
 }


### PR DESCRIPTION
After adding a small change to get Dependabot to work, the unit tests weren't updated accordingly, causing the tests to fail. This PR fixes that issue.