### PR TITLE
Fixed JDK version in workflow

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -14,10 +14,10 @@ jobs:
       - uses: actions/checkout@v5
 
       # Set up JDK
-      - name: Set up JDK 17
+      - name: Set up JDK 21
         uses: actions/setup-java@v4
         with:
-          java-version: '17'
+          java-version: '21'
           distribution: 'temurin'
           cache: maven
 


### PR DESCRIPTION
The workflow was using an outdated version of the JDK. It has been updated from 17 to 21 to match the Maven compiler.