### PR TITLE
Added workflow dispatch to workflow

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -5,6 +5,7 @@ on:
     branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
+  workflow_dispatch
 
 jobs:
   build:


### PR DESCRIPTION
Added the `workflow_dispatch` line to the CICD workflow, which allows the workflow to be ran through the Actions page