### PR TITLE
Added missing colon to workflow

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -5,7 +5,7 @@ on:
     branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
-  workflow_dispatch
+  workflow_dispatch:
 
 jobs:
   build:


### PR DESCRIPTION
A colon was missing in the `workflow_dispatch` line, which broke the workflow