### PR TITLE
Fixed Super Linter validating all languages

### DIFF
--- a/.github/workflows/superlinter.yaml
+++ b/.github/workflows/superlinter.yaml
@@ -17,6 +17,13 @@ jobs:
       - name: GitHub Super Linter
         uses: github/super-linter@v5
         env:
-          VALIDATE_ALL_CODEBASE: true
+          VALIDATE_ALL_CODEBASE: false
+          VALIDATE_JAVA: true
+          VALIDATE_YAML: false
+          VALIDATE_HTML: false
+          VALIDATE_CSS: false
+          VALIDATE_JAVASCRIPT_STANDARD: false
+          VALIDATE_MARKDOWN: false
+          VALIDATE_NATURAL_LANGUAGE: false
           DEFAULT_BRANCH: main
           GITHUB_TOKEN: ${{ secrets.LINTER_TOKEN }}


### PR DESCRIPTION
Modified superlinter.yaml to only check Java code, as it was checking every language previously